### PR TITLE
Disable parallel build

### DIFF
--- a/org.freedesktop.LinuxAudio.Plugins.Cardinal.yml
+++ b/org.freedesktop.LinuxAudio.Plugins.Cardinal.yml
@@ -29,6 +29,7 @@ modules:
     build-options:
       env:
         AR: gcc-ar
+    no-parallel-make: true
     build-commands:
       - make PREFIX=${FLATPAK_DEST} SYSDEPS=true WITH_LTO=false -j $FLATPAK_BUILDER_N_JOBS
       - make PREFIX=${FLATPAK_DEST} install


### PR DESCRIPTION
- it fails randomly

The 23.08 build fail twice, each time on a different arch.