### PR TITLE
Remove appstream compose

### DIFF
--- a/org.freedesktop.LinuxAudio.Plugins.Cardinal.yml
+++ b/org.freedesktop.LinuxAudio.Plugins.Cardinal.yml
@@ -3,7 +3,6 @@ runtime: org.freedesktop.LinuxAudio.BaseExtension
 sdk: org.freedesktop.Sdk//23.08
 runtime-version: stable
 build-extension: true
-appstream-compose: false
 branch: '23.08'
 build-options:
   prefix: /app/extensions/Plugins/Cardinal
@@ -39,8 +38,6 @@ modules:
       - ln -s lib/vst3 ${FLATPAK_DEST}/vst3
       - ln -s lib/clap ${FLATPAK_DEST}/clap
       - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Plugins.Cardinal.metainfo.xml
-      - appstream-compose --basename=org.freedesktop.LinuxAudio.Plugins.Cardinal --prefix=${FLATPAK_DEST}
-        --origin=flatpak org.freedesktop.LinuxAudio.Plugins.Cardinal
     sources:
       - type: archive
         url: https://github.com/DISTRHO/Cardinal/releases/download/24.04/cardinal-24.04.tar.xz


### PR DESCRIPTION
- it's now handled automatically
- it will be gone in the next runtime